### PR TITLE
Use better practices for Java regex example

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,12 +4,31 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.example</groupId>
-    <artifactId>java</artifactId>
+    <groupId>fix.paypal</groupId>
+    <artifactId>FixPaypalRegex</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>
+                                FixPaypalRegex
+                            </mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
 </project>

--- a/java/src/main/java/FixPaypalRegex.java
+++ b/java/src/main/java/FixPaypalRegex.java
@@ -1,26 +1,17 @@
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
 public class FixPaypalRegex {
-
+    private static final Pattern PATTERN = Pattern.compile("[0-9]{3,}|call|contact|\\\\+1");
     public static void main(String[] args) {
-        BufferedReader reader;
-
-        try {
-            reader = new BufferedReader(new FileReader("invoices.txt"));
-            String line = reader.readLine();
-
-            while (line != null) {
-                if (Pattern.compile("([0-9]{3,}|call|contact|\\\\+1)").matcher(line).find()){
+        try (BufferedReader reader = new BufferedReader(new FileReader("invoices.txt"))) {
+            reader.lines().forEach(line -> {
+                if (PATTERN.matcher(line).find()){
                     System.out.println("ඞ sus thing found: " + line);
                 }
-                line = reader.readLine();
-            }
-
-            reader.close();
+            });
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This PR makes a few changes to the Java example for better practices. (If this goes into the PayPal codebase, they'll want good coding practices 😉 )
- Uses try-with-resources to ensure the file reader is closed under all circumstances
- Compiles the regex only once and re-uses it since it doesn't change
- Uses Java 8 stream on BufferedReader for more streamlined code
- Removes capture group from regex. Does not affect functionality of `|`s ([try it](https://regex101.com/r/DG2rm3/1))

How to use:
1. Copy `invoices.txt` to project root (`java` folder)
2. With Maven installed, run the command `mvn package` from the project root
3. Run `java -jar target/FixPaypalRegex-1.0-SNAPSHOT.jar`