### PR TITLE
score_text_v2.py: better compatibility and fixed typo

### DIFF
--- a/python/score_text_v2.py
+++ b/python/score_text_v2.py
@@ -8,7 +8,7 @@ import re
 # "PayPal will never ask for your password or financial details by email or message, or over the phone.")
 # "Forward suspicious messages to phishing@paypal.com and then delete them.")
 #
-# You won't loose customers doing this and your customers will be safe.
+# You won't lose customers doing this and your customers will be safe.
 
 # Do not include spaces or uppercase characters for easier matching.
 KEYWORDS = { 

--- a/python/score_text_v2.py
+++ b/python/score_text_v2.py
@@ -25,7 +25,7 @@ KEYWORDS = {
 }
 
 # Returns list of matches and the suspicious score.
-def analyze_text(text: str) -> list[str] | float:
+def analyze_text(text):
     text = re.sub(r'\s+', '', text).lower() # Remove all spaces, tabs, newlines and make the text lower-case for better easier matching.
 
     sus = []


### PR DESCRIPTION
I've removed type hinting so the code can run on any version of python 3, as the type annotations we've used before were only for python >=3.10

Also fixed a typo in the comments as mentioned by another contributor, english is not my first language :^)