### PR TITLE
Making it more obfuscated!

### DIFF
--- a/c/obfuscated_way.c
+++ b/c/obfuscated_way.c
@@ -1,9 +1,10 @@
 #include <stdio.h>
 #include <ctype.h>
 
-char l[512];int c(char f[]){int i=0,m=0,c;while(c=tolower(l[i++])){char
-e=tolower(f[m]);if(!e)return 1;else if(c==e){if(f[m+++1]=='\0')return 1
-;}else m=0;}return 0;}int main(){int s=0,t=0;FILE*fh=fopen("../invoice"
-"s.txt","rb");while(fgets(l,512,fh))++t&&(c("suspicious")||c("unauthor"
-"ized")||c("+1")||c("geek squad")||c(" call"))&&s++;printf("%d / %d\n",
-s,t);}
+char l[512];i,m,e,s,t,d;c(char*f){i=0,m=0;while(d=
+tolower(l[i++])){e=tolower(f[m]);if(!e)return 1;if
+(d==e){if(!f[m+++1])return 1;}else m=0;}return 0;}
+main(){FILE*f=fopen("../invoices.txt","rb");while(
+fgets(l,512,f))++t&&(c("suspicious")||c("unauthor"
+"ized")||c("+1")||c("geek squad")||c(" call"))&&++
+s;printf("%d / %d\n",s,t);}


### PR DESCRIPTION
### changelog:
- every `int` declaration was moved outside a function as declarations outside functions are implicitly `int`s.
- same for the function `c` and `main`, we don't have to declare them as `int`.
- the variable `c` was renamed to `d` to avoid conflicts with the function
- `fh` was renamed `f` because it's shorter
- the char `f[]` in the function `c` was changed to a `char*f`, which is shorter and we can do that without danger since we do not edit it.
- `if(f[m+++1]=='\0')` is equivalent to `if(f[m+++1]==0)` and subsequently to `if(!f[m+++1])`
### Additional notes:
- a lot of variables are declared but not initialised and then used with `++`, this could cause some problems with some specific compilers but everything works well with both clang 14 and gcc 11.3 here
- i can't declare `l` as an `int[]` because `fgets` disagrees
- there is probably a way to optimise more by replacing the `if`s with ternary operators but i'm too lazy to do that